### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:edit, :show, :update, :destroy]
-
+  before_action :permited_user, only: [:edit, :update, :destroy]
     def index
       @items = Item.all.order("created_at DESC")
       
@@ -24,7 +24,7 @@ class ItemsController < ApplicationController
     end
 
     def edit
-      redirect_to root_path unless current_user.id == @item.user_id
+      
     end
 
     def update
@@ -55,6 +55,11 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
+
+def permited_user
+   redirect_to root_path unless current_user.id == @item.user_id
+end
+
 
 end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:edit, :show, :update]
+  before_action :set_item, only: [:edit, :show, :update, :destroy]
 
     def index
       @items = Item.all.order("created_at DESC")
@@ -35,6 +35,12 @@ class ItemsController < ApplicationController
       end
    end
 
+   def destroy
+    if @item.user == current_user
+    @item.destroy
+    redirect_to root_path
+    end
+   end
 
 
     private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
 <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
 <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only:[:index, :new, :create, :show, :edit, :update ]
+  resources :items, only:[:index, :new, :create, :show, :edit, :update, :destroy ]
 end


### PR DESCRIPTION
# what
商品削除機能の実装

# why
投稿した本人が商品を削除できる機能を実装するため。


• ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/c25bebc2c3d9e66cc17ebfcd5f64dd4f